### PR TITLE
Add Flutter entrypoint and MyApp widget

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+
+void main() => runApp(const MyApp());
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'MyApp',
+      home: Scaffold(
+        appBar: AppBar(
+          title: const Text('MyApp'),
+        ),
+        body: const Center(
+          child: Text('Hello, world!'),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add basic `main.dart` with `MyApp` widget and entrypoint

## Testing
- `dart format lib/main.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68a431acd6588329b59f5a793e765f89